### PR TITLE
Use display instead of word

### DIFF
--- a/denops/@ddu-sources/rg.ts
+++ b/denops/@ddu-sources/rg.ts
@@ -105,7 +105,8 @@ export class Source extends BaseSource<Params> {
       const text = result ? get_param(result, 4) : "";
 
       return {
-        word: line,
+        word: text,
+        display: line,
         action: {
           path: join(cwd, path),
           lineNr: lineNr,

--- a/doc/ddu-source-rg.txt
+++ b/doc/ddu-source-rg.txt
@@ -66,7 +66,7 @@ EXAMPLES					*ddu-source-rg-examples*
     "call ddu#custom#patch_global({
     "    \   'sourceOptions': {
     "    \     'rg': {
-    "    \       'converters': ['converter_display_word'],
+    "    \       'matchers': ['converter_display_word', 'matcher_substring'],
     "    \     },
     "    \   }
     "    \ })

--- a/doc/ddu-source-rg.txt
+++ b/doc/ddu-source-rg.txt
@@ -59,6 +59,17 @@ EXAMPLES					*ddu-source-rg-examples*
             \   }},
             \ })
     endfunction
+
+    " If you want to narrow by filename, please install
+    " "ddu-filter-converter_display_word".
+    " https://github.com/Shougo/ddu-filter-converter_display_word
+    "call ddu#custom#patch_global({
+    "    \   'sourceOptions': {
+    "    \     'rg': {
+    "    \       'converters': ['converter_display_word'],
+    "    \     },
+    "    \   }
+    "    \ })
 <
 ==============================================================================
 PARAMS						*ddu-source-rg-params*


### PR DESCRIPTION
I have changed "word" to "display".
Because I don't want to narrow by filename.

You can change the behavior by `converter_display_word`.