### PR TITLE
Support search from multiple paths

### DIFF
--- a/denops/@ddu-sources/rg.ts
+++ b/denops/@ddu-sources/rg.ts
@@ -21,6 +21,7 @@ type Params = {
   args: string[];
   input: string;
   path: string;
+  paths: string[];
   highlights: HighlightGroup;
 };
 
@@ -66,7 +67,8 @@ export class Source extends BaseSource<Params> {
       return {
         word: header + text,
         action: {
-          path: join(cwd, path),
+          // When paths given, path is absolute path
+          path: path.startsWith("/") ? path : join(cwd, path),
           lineNr,
           col: col + 1,
           text,
@@ -110,7 +112,8 @@ export class Source extends BaseSource<Params> {
         word: text,
         display: line,
         action: {
-          path: join(cwd, path),
+          // When paths given, path is absolute path
+          path: path.startsWith("/") ? path : join(cwd, path),
           lineNr,
           col,
           text,
@@ -129,7 +132,12 @@ export class Source extends BaseSource<Params> {
           return;
         }
 
-        const cmd = ["rg", ...args.sourceParams.args, input];
+        const cmd = [
+          "rg",
+          ...args.sourceParams.args,
+          input,
+          ...args.sourceParams.paths,
+        ];
         const cwd = args.sourceParams.path != ""
           ? args.sourceParams.path
           : await fn.getcwd(args.denops) as string;
@@ -210,6 +218,7 @@ export class Source extends BaseSource<Params> {
       args: ["--column", "--no-heading", "--color", "never"],
       input: "",
       path: "",
+      paths: [],
       highlights: {
         path: "Normal",
         lineNr: "Normal",

--- a/doc/ddu-source-rg.txt
+++ b/doc/ddu-source-rg.txt
@@ -95,6 +95,12 @@ path	(string)
 
 	Default: ""
 
+paths	(string[])
+	Search paths.
+	If it is empty, |path| is used instead.
+
+	Default: []
+
 highlights	(list)
 	Highlight groups for path, lineNr and search word.
 	Default: "Normal" for path and lineNr.


### PR DESCRIPTION
`rg --help` describes ripgrep can receive multiple paths. 
`rg [OPTIONS] PATTERN [PATH ...]`

Existing `path` options is need to use the path as cwd to run Deno.run, so I keep the `path` option.

---

example.
![cap](https://user-images.githubusercontent.com/1688137/212481427-5c4f77b7-c253-4664-bfb0-240b7501772f.gif)

```
local paths = ... -- collect paths from items

vim.fn["ddu#start"]({
  name = 'rg',
  push = true,
  sources = {
    {
      name = "rg",
      params = {
        path = vim.fn.getcwd(),
        input = vim.fn["input"]("Pattern: "),
        paths = paths
      },
    }
  },
})
```