### PR TITLE
Add kensaku integration

### DIFF
--- a/doc/ddu-source-rg.txt
+++ b/doc/ddu-source-rg.txt
@@ -100,5 +100,10 @@ highlights	(list)
 	Default: "Normal" for path and lineNr.
 	Default: "Search" for word
 
+kensaku 	(boolean)
+	If true, apply lambdalisue/kensaku.vim to search pattern.
+	Note: To use kensaku, lambdalisue/kensaku.vim is necessary.
+	Default: false
+
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:


### PR DESCRIPTION
Add support for [lambdalisue/kensaku.vim](https://github.com/lambdalisue/kensaku.vim).
Kensaku provides search by Roma-ji based Japanese text.

e.g.
Search in `tsuika` :
![image](https://user-images.githubusercontent.com/47162587/212796510-12bbc176-f2e9-4c15-bab2-fe87742891ce.png)
