### PR TITLE
return relative paths if given

### DIFF
--- a/denops/@ddu-sources/rg.ts
+++ b/denops/@ddu-sources/rg.ts
@@ -121,8 +121,7 @@ export class Source extends BaseSource<Params> {
         word: text,
         display: line,
         action: {
-          // When paths given, path is absolute path
-          path: path.startsWith("/") ? path : join(cwd, path),
+          path,
           lineNr,
           col,
           text,


### PR DESCRIPTION
I noticed that ddu-source-rg was returning absolute paths to items, so when ddu opened a file the entire path displayed in the statusline.