### PR TITLE
add cmd param

### DIFF
--- a/denops/@ddu-sources/rg.ts
+++ b/denops/@ddu-sources/rg.ts
@@ -23,6 +23,7 @@ type InputType =
   | "migemo";
 
 type Params = {
+  cmd: string;
   args: string[];
   displayText: boolean;
   inputType: InputType;
@@ -162,7 +163,7 @@ export class Source extends BaseSource<Params> {
         }
 
         const cmd = [
-          "rg",
+          args.sourceParams.cmd ?? "rg",
           ...args.sourceParams.args,
           "--",
           input,

--- a/doc/ddu-source-rg.txt
+++ b/doc/ddu-source-rg.txt
@@ -87,6 +87,12 @@ EXAMPLES					*ddu-source-rg-examples*
 ==============================================================================
 PARAMS						*ddu-source-rg-params*
 
+						*ddu-source-rg-param-cmd*
+cmd	(string)
+	Command to execute rg.
+
+	Default: "rg"
+
 						*ddu-source-rg-param-args*
 args	(string[])
 	Execute rg with args.


### PR DESCRIPTION
When denops is launching a "Shared server", environment variables is not passed and the "rg not found" error cause.
To specify the absolute "rg" path in `sourceParams` resolve the problem.